### PR TITLE
Made one fix to adjust the flaky test case

### DIFF
--- a/src/test/java/com/google/cloud/teleport/bigtable/CassandraBaseTest.java
+++ b/src/test/java/com/google/cloud/teleport/bigtable/CassandraBaseTest.java
@@ -35,19 +35,23 @@ public class CassandraBaseTest {
   static Scassandra scassandra;
 
   private static Map.Entry<Integer, Integer> getFreePort() throws IOException {
-    int firstPort;
     ServerSocket firstSocket = new ServerSocket(0);
-    firstPort = firstSocket.getLocalPort();
-
-    int secondPort;
-    ServerSocket secondSocket = new ServerSocket(0);
-    secondPort = secondSocket.getLocalPort();
-
+    int firstPort = firstSocket.getLocalPort();
     firstSocket.close();
+
+    ServerSocket secondSocket = new ServerSocket(0);
+    int secondPort = secondSocket.getLocalPort();
     secondSocket.close();
 
+    while (secondPort == firstPort) {
+      secondSocket = new ServerSocket(0);
+      secondPort = secondSocket.getLocalPort();
+      secondSocket.close();
+    }
+
     return new SimpleEntry<>(firstPort, secondPort);
-  }
+}
+
 
   @BeforeClass
   public static void startScassandraServer() throws Exception {


### PR DESCRIPTION
# What is the purpose of this PR
This PR tries to provide a fix for the error resulting from the flaky test: 
`com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest.testTinyIntColumn`.

The mentioned tests may fail or pass without changes made to the source code when it is run multiple times due to of the dependency on nondeterministic random number. Note that, the problem still appears sometimes. Details in Fix section.

# Why the tests fail
The test fails because CassandraRowMapperFnTest requests two open ports randomly. The randomly generated ports can become the same port in some cases. So, the test may fail.

# Reproduce the test failure
Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest#testTinyIntColumn
```
Fixing the flaky test now may prevent flaky test failures in future Java versions.


# Expected results
Both tests should run successfully when run with NonDex.
# Actual Result
We get the following failure for the test:
```
[ERROR] testTinyIntColumn(com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest)  Time elapsed: 0.669 s  <<< ERROR!
org.scassandra.http.client.ActivityRequestFailed: Clearing of connections failed
Caused by: org.apache.http.NoHttpResponseException: localhost:34945 failed to respond

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   CassandraRowMapperFnTest>CassandraBaseTest.setup:74 » ActivityRequestFailed Cl...
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
```
# Fix
We tried to fix it by checking whether the randomly generated port numbers are same. If they are same, we generate the ports again. Despite the fix, the test case remains flaky. But it is nonetheless an improvement over existing TC implementation and has less chance of flaky issue occurring than the existing one. So we made the PR.